### PR TITLE
fix: action failure on branch with perennial parent

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+## Description
+
+
+
 ## Stack
 
 <!-- branch-stack -->

--- a/dist/index.js
+++ b/dist/index.js
@@ -46840,8 +46840,13 @@ var inputs = {
     return mainBranch;
   },
   async getPerennialBranches(octokit, config2, context3) {
-    const { data } = await octokit.rest.repos.listBranches({ ...context3.repo });
-    const repoBranches = data.map((branch) => branch.name);
+    const [{ data: unprotectedBranches }, { data: protectedBranches }] = await Promise.all([
+      octokit.rest.repos.listBranches({ ...context3.repo }),
+      octokit.rest.repos.listBranches({ ...context3.repo, protected: true })
+    ]);
+    const repoBranches = [...unprotectedBranches, ...protectedBranches].map(
+      (branch) => branch.name
+    );
     let explicitBranches = [];
     explicitBranches = config2?.branches?.perennials ?? explicitBranches;
     const perennialBranchesInput = core2.getMultilineInput("perennial-branches", {
@@ -46850,7 +46855,7 @@ var inputs = {
     });
     explicitBranches = perennialBranchesInput.length > 0 ? perennialBranchesInput : explicitBranches;
     let perennialRegex;
-    perennialRegex = config2?.branches?.perennialRegex ?? perennialRegex;
+    perennialRegex = config2?.branches?.["perennial-regex"] ?? perennialRegex;
     const perennialRegexInput = core2.getInput("perennial-regex", {
       required: false,
       trimWhitespace: true
@@ -46906,7 +46911,7 @@ var configSchema = object({
   branches: object({
     main: string3().optional(),
     perennials: array(string3()).optional(),
-    perennialRegex: string3().optional()
+    "perennial-regex": string3().optional()
   }).optional()
 });
 var configFile;

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ const configSchema = object({
   branches: object({
     main: string().optional(),
     perennials: array(string()).optional(),
-    perennialRegex: string().optional(),
+    'perennial-regex': string().optional(),
   }).optional(),
 })
 

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -2,6 +2,7 @@ import { describe, beforeEach, it, expect, vi } from 'vitest'
 import type * as github from '@actions/github'
 import { inputs } from './inputs'
 import type { Octokit } from './types'
+import type { Config } from './config'
 
 beforeEach(() => {
   vi.unstubAllEnvs()
@@ -24,7 +25,7 @@ describe('getMainBranch', () => {
         },
       },
     } as unknown as Octokit
-    const config = {}
+    const config: Config = {}
     const context = {
       repo: {},
     } as unknown as typeof github.context
@@ -46,7 +47,7 @@ describe('getMainBranch', () => {
         },
       },
     } as unknown as Octokit
-    const config = {
+    const config: Config = {
       branches: {
         main: 'main',
       },
@@ -115,10 +116,10 @@ describe('getPerennialBranches', () => {
       },
     },
   } as unknown as Octokit
-  const config = {
+  const config: Config = {
     branches: {
       perennials: ['dev', 'staging', 'prod'],
-      perennialRegex: '^release-.*$',
+      'perennial-regex': '^release-.*$',
     },
   }
   const context = {


### PR DESCRIPTION
## Description

Fixes #8.

Error was caused by two issues:

1. `octokit.rest.repos.listBranches` can only list either unprotected branches or protected branches at the same time. Most of the time, perennial branches are also protected branches. This meant that perennial branches weren't being included in the action's inputs because they simply weren't returned in the API response. Calling `octokit.rest.repos.listBranches` again with `protected: true` solves this issue.
2. The TOML parser was incorrectly assumed to automatically camelcase property names. This meant that `perennial-regex` from `.git-branches.toml` was never properly read. Fixed by correcting the  relevant `zod` schema.

## Stack

<!-- branch-stack -->

- `main`
  - \#10 :point\_left:
