### PR TITLE
config: support SSH identities & update editorconfig version

### DIFF
--- a/.editorconfig-checker
+++ b/.editorconfig-checker
@@ -1,5 +1,5 @@
 {
-  "Version": "v3.0.0",
+  "Version": "v3.0.1",
   "Verbose": false,
   "Format": "",
   "Debug": false,

--- a/.git-branches.toml
+++ b/.git-branches.toml
@@ -9,6 +9,10 @@ sync-upstream = true
 [branches]
 main = "main"
 
+[hosting]
+platform = "github"
+origin-hostname = "github.com"
+
 [sync-strategy]
 feature-branches = "merge"
 perennial-branches = "rebase"


### PR DESCRIPTION
## Description

- Explicitly define hosting platform & hostname to support multiple SSH identities when contributing using Git Town.
- Updated EditorConfig checker's configuration file to `v3.0.1`.

## Stack

<!-- branch-stack -->

- `main`
  - \#31 :point\_left:
    - \#32
