### PR TITLE
Update deprecated Git Town configuration option

### DIFF
--- a/.git-branches.toml
+++ b/.git-branches.toml
@@ -1,7 +1,7 @@
 # Git Town configuration file
 
 push-hook = true
-share-new-branches = false
+share-new-branches = "no"
 ship-delete-tracking-branch = false
 sync-before-ship = false
 sync-upstream = true


### PR DESCRIPTION
## Description

This updates a deprecated config option, removing a warning emitted by the Git Town executable.

## Stack

- `main` <!-- branch-stack -->
  - \#71 :point\_left:
