### PR TITLE
Use checkout@v5 - bumps minimum node.js to v24 and removes deprecation notice

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Env
         id: setup-env
@@ -54,7 +54,7 @@ jobs:
       - if: ${{ failure() && steps.diff.outcome == 'failure' }}
         name: Upload Artifact
         id: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Env
         id: setup-env
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Env
         id: setup-env
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Env
         id: setup-env

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         id: initialize

--- a/.github/workflows/git-town.yml
+++ b/.github/workflows/git-town.yml
@@ -19,6 +19,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Git Town
         uses: ./

--- a/.github/workflows/git-town.yml
+++ b/.github/workflows/git-town.yml
@@ -19,6 +19,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Git Town
         uses: ./

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: git-town/action@v1
 ```
 
@@ -166,7 +166,7 @@ it into the actions's `github-token` input to grant it sufficient permissions:
 
 ```yaml
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: git-town/action@v1
       with:
         github-token: ${{ secrets.GIT_TOWN_PAT }} # 👈 Add this to `git-town.yml`


### PR DESCRIPTION
## Description

This resolves the following deprecation warning:

<img width="1623" height="275" alt="image" src="https://github.com/user-attachments/assets/dd07183a-5e40-46c2-9f15-81c7c07dd9a3" />

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, git-town/action@v1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Stack

<!-- branch-stack -->
